### PR TITLE
Updated Readme.md (still requiring Umesh inputs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
-# TED
+# Telstra Event Detection API
+## Introduction
+The TED API provides the ability to subscribe to and receive network events for a given set of mobile numbers.
+The first step to use beta TED API is to create a developer account on beta dev portal and request for access to the API. To request for an API key contact us at [t.dev@team.telstra.com](t.dev@team.telstra.com)
+
+## Beta release features
+For this release we've included following features
+
+host_url: https://slot2.org005.t-dev.telstra.net <br>
+oauth_path: [/v1/oauth/token](https://slot2.org005.t-dev.telstra.net/v1/oauth/token) <br>
+subscription_path: [/v2/messages/provisioning/subscriptions](https://slot2.org005.t-dev.telstra.net/v2/messages/provisioning/subscriptions) <br>
+get_event: [/v1/eventdetection/events/simswap](https://slot2.org005.t-dev.telstra.net/v1/eventdetection/events/simswap) <br>
+
+
+| Feature | Description |
+| --- | --- |
+| `Event Subscription` | Subscription informs the API to start listening for particular event. Current events are sim swap, port out(or number de-activation), international roaming. <br> Sim Swap is the only event available during beta release  |
+| `Event Request` | Request for event history for a given list of mobile numbers <br> Event history is maintained for 90 days|
+| `Push notification` | Provision a callback URL to get push notification as soon as the event occurs. <br> Event history is maintained for 90 days |
+| `Documentation` | Hit Get Started to access technical documentation and get started within minutes |
+
+## Getting access to the API
+To get access to the API, go to MyApps page and create a new application with `Add New App` button. Creation of an app will trigger a request for access to API key.
+
+## Authentication
+To get an OAuth 2.0 Authentication token, pass through your Consumer Key and Consumer Secret that you received when you registered for the Messages API key. The `grant_type` should be left as `client_credentials` and the scope as `NSMS`. The token will expire in one hour. Get your keys by registering at our [Developer Portal](https://test-apac-demo3.devportal.apigee.com/).
+```sh
+#!/bin/bash
+# Obtain these keys from the Telstra Developer Portal
+CONSUMER_KEY="your consumer key"
+CONSUMER_SECRET="your consumer secret"
+curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials&client_id=$CONSUMER_KEY&client_secret=CONSUMER_SECRET&scope=NSMS' \
+  'https://slot2.apipractice.t-dev.telstra.net/v1/oauth/token'
+```
+### Response
+```json
+{
+  "expires_in" : "35999",
+  "access_token" : "1234567890123456788901234567"
+}
+```
+
+## Create subscription
+Invoke subscription API to create one or more subscriptions
+```sh
+#!/bin/bash
+curl -X POST \
+  https://slot2.apipractice.t-dev.telstra.net/v2/messages/provisioning/subscriptions \
+  -H 'authorization: Bearer $TOKEN' \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -d '{
+        "phoneNumbers": [
+          "61412345678"
+          ]
+      }'
+```
+Parameters for the subscription API are;
+
+| Parameter |Mandatory| Description |
+| --- | --- | --- |
+| `phoneNumbers` | Y | List of numbers to create a subscription for |
+| `notifyURL` | N | A callback URL that will be POSTed to whenever a new message arrives at this destination address. If this is not provided then you can make use the Get Replies API to poll for messages |
+### Response
+A typical response will look like;
+```
+{
+    "todo": "Umesh to provide information"
+}
+```
+The fields mean;
+
+| Field | Description |
+| --- | --- |
+| `destinationAddress` | The provisioned number assigned to your app. Your customers can send replies to this number. If the `notifyURL` is provided then the replies will be POSTed to it. |
+
+## Get Event (sim swap)
+To get sim swap event invoke following API
+```sh
+#!/bin/bash
+# Use the TED API to get events
+AccessToken="Consumers Access Token"
+Dest="Destination number"
+curl -X post -H "Authorization: Bearer $AccessToken" \
+  -H "Content-Type: application/json" \
+  -d '{
+      "event": "event-name"
+      "phoneNumbers": [
+        "61467754783"
+        ]
+      }' \
+      https://slot2.org005.t-dev.telstra.net/v1/eventdetection/events/simswap
+```
+A number of parameters can be used in this call, these are;
+
+| Parameter | Description |
+| --- | --- |
+| `event` | Name of event for which information is requested |
+| `phoneNumbers` | List of numbers for information is requested |
+
+### Response
+A typical response will look like;
+```json
+{
+    "todo": "Umesh to add this"
+}
+```
+The fields mean;
+
+| Field | Description |
+| --- | --- |
+| `todo` | Umesh to add this |
+
+
+## Sample Apps
+On the way
+
+## SDKs
+On the way

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The first step to use beta TED API is to create a developer account on beta dev 
 ## Beta release features
 For this release we've included following features
 
-host_url: https://slot2.org005.t-dev.telstra.net <br>
-oauth_path: [/v1/oauth/token](https://slot2.org005.t-dev.telstra.net/v1/oauth/token) <br>
-subscription_path: [/v2/messages/provisioning/subscriptions](https://slot2.org005.t-dev.telstra.net/v2/messages/provisioning/subscriptions) <br>
-get_event: [/v1/eventdetection/events/simswap](https://slot2.org005.t-dev.telstra.net/v1/eventdetection/events/simswap) <br>
+host\_url: https://slot2.org005.t-dev.telstra.net <br>
+oauth\_path: [/v1/oauth/token](https://slot2.org005.t-dev.telstra.net/v1/oauth/token) <br>
+subscription\_path: [/v2/messages/provisioning/subscriptions](https://slot2.org005.t-dev.telstra.net/v2/messages/provisioning/subscriptions) <br>
+get\_event: [/v1/eventdetection/events/simswap](https://slot2.org005.t-dev.telstra.net/v1/eventdetection/events/simswap) <br>
 
 
 | Feature | Description |
@@ -24,6 +24,7 @@ To get access to the API, go to MyApps page and create a new application with `A
 
 ## Authentication
 To get an OAuth 2.0 Authentication token, pass through your Consumer Key and Consumer Secret that you received when you registered for the Messages API key. The `grant_type` should be left as `client_credentials` and the scope as `NSMS`. The token will expire in one hour. Get your keys by registering at our [Developer Portal](https://test-apac-demo3.devportal.apigee.com/).
+
 ```sh
 #!/bin/bash
 # Obtain these keys from the Telstra Developer Portal
@@ -43,6 +44,7 @@ curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
 
 ## Create subscription
 Invoke subscription API to create one or more subscriptions
+
 ```sh
 #!/bin/bash
 curl -X POST \
@@ -63,7 +65,8 @@ Parameters for the subscription API are;
 | `phoneNumbers` | Y | List of numbers to create a subscription for |
 | `notifyURL` | N | A callback URL that will be POSTed to whenever a new message arrives at this destination address. If this is not provided then you can make use the Get Replies API to poll for messages |
 ### Response
-A typical response will look like;
+A typical response will look like
+
 ```
 {
     "todo": "Umesh to provide information"
@@ -77,6 +80,7 @@ The fields mean;
 
 ## Get Event (sim swap)
 To get sim swap event invoke following API
+
 ```sh
 #!/bin/bash
 # Use the TED API to get events
@@ -101,6 +105,7 @@ A number of parameters can be used in this call, these are;
 
 ### Response
 A typical response will look like;
+
 ```json
 {
     "todo": "Umesh to add this"


### PR DESCRIPTION
# Event Detection API
## Introduction
The Telstra Event Detection API provides the ability to subscribe to and receive network events for a given set of mobile numbers.
The first step to use beta Event Detection API is to register your developer account and request for access to the API. To request for beta access to Event Detection API please complete the BETA request form;
<insert BETA Request form link>



## Beta release features
For the beta release we've included following features:

| Feature | Description |
| --- | --- |
| `Event Subscription` | Subscription informs the API to register a users mobile number so that you can poll those numbers for particular events. You can subscribe and unsubscribe numbers (opt in and opt out) against this service. Current events are SIM swap, port out (or number de-activation), international roaming. SIM Swap is the only event available during beta release.  |
| `Event Request` | Request for event history for a given list of mobile numbers. Event history is maintained for 90 days.|
| `Push notification` | Provision a callback URL to get push notification as soon as the event occurs. Event history is maintained for 90 days |

## Getting access to the API
To get access to the API, you will need to complete the BETA access request form. Once beta access has been approved, Telstra will create an application for you with a set of keys, we will then inform you when this has been completed. Then go to MyApps page to access your API Keys for beta Event Detection API.

Once you have access to the Event Detection API follow these steps to get started:
1. Autheticate by getting an Oauth token.
2. Provision your app by getting a dedicated mobile number.
3. Subscribe user mobile numbers to events.
4. Get events for subscribed user mobile numbers.

## Authentication
To get an OAuth 2.0 Authentication token, pass through your Consumer Key and Consumer Secret that you received when Telstra created your beta Event Detection app in MyApps. The `grant_type` should be left as `client_credentials` and the scope as `v1_eventdetection_simswap`. The token will expire in one hour.

```sh
#!/bin/bash
# Obtain these keys from the Telstra Developer Portal
CONSUMER_KEY="your consumer key"
CONSUMER_SECRET="your consumer secret"
curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=$CONSUMER_KEY&client_secret=CONSUMER_SECRET&scope=v1_eventdetection_simswap' \
  'https://tapi.telstra.com/v2/oauth/token'
```
### Response
```json
{
    "access_token" : "1234567890123456788901234567",
    "token_type" : "Bearer",
    "expires_in" : "35999"
}
```

## Provisioning service
Invoke the provisioning API to allow your application to use the Event Detection API. This API will return a dedicated mobile number that is associated with your application.

```sh
#!/bin/bash
curl -X POST \
  https://tapi.telstra.com/v2/messages/provisioning/subscriptions \
  -H 'authorization: Bearer $TOKEN' \
  -H 'content-type: application/json' \
  -d '{}'
```


The following parameter can be used in this call;

| Parameter | Description |
| --- | --- |
| `activeDays` | The number of days your provisioned mobile number will remain active. Once expired you will need to invoke the provisioning API again to continue using the Event Detection API. |

### Response
A typical response will look like;

```
{
    "destinationAddress": "+61412345678"
}
```
The fields mean;

| Field | Description |
| --- | --- |
| `destinationAddress` | The provisioned number assigned to your app. This registers your use of the Event Detection API  |


## Subscribe users (Umesh input required)
Subscribing users mobile numbers informs the API to register that mobile number so that you can poll those numbers for particular events. You can subscribe and unsubscribe numbers (opt in and opt out) against this service. Only numbers that are opted in (i.e. subscribed) can be polled for events. SIM Swap is the only event available during beta release.

```sh
#!/bin/bash
curl -X POST \
  https://tapi.telstra.com/v1/eventdetection/ \
  -H 'authorization: Bearer $TOKEN' \
  -H 'content-type: application/json' \
  -d '{}'
```

The following parameter can be used in this call;

| Parameter | Description |
| --- | --- |
| `???` | ??? |

### Response
A typical response will look like;
```
{
    ???
}
```


## Get Event (SIM swap)
To get SIM swap event invoke following API

```sh
#!/bin/bash
# Use the TED API to get events
AccessToken="Consumers Access Token"
Dest="Destination number"
curl -X post -H "Authorization: Bearer $AccessToken" \
  -H "Content-Type: application/json" \
  -d '{
      "event": "event-name"
      "phoneNumbers": [
        "61467754783"
        ]
      }' \
      https://tapi.telstra.com/v1/eventdetection/events/simswap
```
A number of parameters can be used in this call, these are;

| Parameter | Description |
| --- | --- |
| `event` | Name of event for which information is requested |
| `phoneNumbers` | List of numbers for information is requested |

### Response
A typical response will look like;

```json
{
    "todo": "Umesh to add this"
}
```
The fields mean;

| Field | Description |
| --- | --- |
| `todo` | Umesh to add this |